### PR TITLE
fix: implement solution for top-level @isTest and inner classes without access modifiers being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@
 - Fixed CSS bug for TOC method descriptions: `text-overflow: ellipsis;` was not working as `white-space: nowrap;` was missing. Also made the width of the descriptions smaller, as they were extending across the whole page which I found a bit distracting. Now will have ellipsis overflow at 500px;
 - Fixed line-height CSS for TOC method descriptions. The bottom of letters like 'g' and '__' were getting cut off, now full line is visible.
 - Fix comparisons when getting token content so that tokens without values do not get rendered.
+- Fix bug where classes without explicit access modifiers (either top-level `@isTest` or inner classes), assumed to be private, are ignored by the parser. [See](https://github.com/no-stack-dub-sack/ApexDoc2/pull/3).

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Located in the lines above the class declaration.  The special tokens are all op
 | @author | The author of the class |
 | @date | The date the class was first implemented |
 | @group | A group to display this class under, in the menu hierarchy|
-| @group-content | A relative path to a static html file that provides content about the group|
+| @group-content | A relative path (from the classes source directory) to a static html file that provides content about the group|
 | @description | One or more lines that provide an overview of the class|
 | @deprecated | Indicates class should no longer be used; message should indicate replacement |
 | @see | A fully qualified class or method name; creates a link to that class or method in the documentation. The name must be a fully qualified name, even if its a reference to another method in the same class, e.g. Class.Method, Class.InnerClass, Class.InnerClass.InnerClassMethod|

--- a/TODO
+++ b/TODO
@@ -2,7 +2,8 @@ Testing:
     ☐ Tests, tests, tests! (look into the possibility of snapshot tests to compare expected HTML output with the live output of test source files).
 
 Miscelaneous:
-    ☐ Class renders @description token itself when no token value is provided
-    ☐ If no description is provided for a method, do not show blank space
-    ☐ Do not show 'Parameters' sub-header when param token is provided with no value
-    ☐ Do not make class, property, and method names links, unless a source url is provided
+    ☐ Fix issue where class docs render @description token itself when no token value is provided
+    ☐ Fix issue where ff no description is provided for a method, a blank space is shown beneath in the TOC
+    ☐ Fix issue where 'Parameters' sub-header renders when param token is provided with no value
+    ☐ Do not make class, property, and method names links unless a source url is provided
+    ✔ Fix issue where @isTest and inner classes not explicity given access modifers are ignored @done(19-02-14 22:42)

--- a/src/main/ApexModel.java
+++ b/src/main/ApexModel.java
@@ -95,8 +95,11 @@ public class ApexModel {
         scope = null;
         if (nameLine != null) {
             String str = ApexDoc.strContainsScope(nameLine);
-            if (str != null)
+            if (str != null) {
                 scope = str;
+            } else {
+                scope = "private";
+            }
         }
     }
 }


### PR DESCRIPTION
initially reported [here](https://github.com/SalesforceFoundation/ApexDoc/issues/56#issuecomment-211861803) by @Patlatus. Top level class without access modifiers (must be `@isTest`) and inner classes without access modifiers, both assumed to be private by apex, were being ignored by ApexDoc. This implements a solution for this issue. Now both forms are documented and assumed to be private. However, the fact the the top-level classes must be `@isTest` is still not captured. Eventually, it would be nice to capture this and other class/method annotations such as `@AuraEnabled`, `@future`, `@TestVisible`, etc.