### PR TITLE
feature(parser): re-implement comment parser

### DIFF
--- a/src/main/ApexModel.java
+++ b/src/main/ApexModel.java
@@ -1,24 +1,28 @@
 package main;
 
+import java.util.ArrayList;
+
 public class ApexModel {
 
-    private String deprecated;
+    private String author = "";
+    private String date = "";
+    private String deprecated = "";
+    private String description = "";
+    private String example = "";
+    protected String exception = "";
+    protected String classGroup = "";
+    protected String classGroupContent = "";
+    protected ArrayList<String> params = new ArrayList<String>();
+    private String see = "";
+    protected String returns = "";
+
     private String nameLine;
     private int lineNum;
-    private String description;
-    private String author;
-    private String date;
-    private String returns;
     private String scope;
-    private String example;
-    private String see;
 
+    // model attribute getters / setters
     public String getNameLine() {
         return nameLine;
-    }
-
-    public int getLineNum() {
-        return lineNum;
     }
 
     public void setNameLine(String nameLine, int lineNum) {
@@ -27,60 +31,8 @@ public class ApexModel {
         parseScope();
     }
 
-    public String getDescription() {
-        return description == null ? "" : description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getAuthor() {
-        return author == null ? "" : author;
-    }
-
-    public void setAuthor(String author) {
-        this.author = author;
-    }
-
-    public void setDeprecated(String dep) {
-        this.deprecated = dep;
-    }
-
-    public String getDeprecated() {
-        return deprecated == null ? "" : deprecated;
-    }
-
-    public String getDate() {
-        return date == null ? "" : date;
-    }
-
-    public void setDate(String date) {
-        this.date = date;
-    }
-
-    public String getReturns() {
-        return returns == null ? "" : returns;
-    }
-
-    public void setReturns(String returns) {
-        this.returns = returns;
-    }
-
-    public String getExample() {
-        return example == null ? "" : example;
-    }
-
-    public void setExample(String example) {
-        this.example = example;
-    }
-
-    public String getSee() {
-        return see == null ? "" : see;
-    }
-
-    public void setSee(String see) {
-        this.see = see;
+    public int getLineNum() {
+        return lineNum;
     }
 
     public String getScope() {
@@ -99,6 +51,99 @@ public class ApexModel {
                 scope = str;
             } else {
                 scope = "private";
+            }
+        }
+    }
+
+    // common @token getters
+    public String getDescription() {
+        return description == null ? "" : description;
+    }
+
+    public String getAuthor() {
+        return author == null ? "" : author;
+    }
+
+    public String getDeprecated() {
+        return deprecated == null ? "" : deprecated;
+    }
+
+    public String getDate() {
+        return date == null ? "" : date;
+    }
+
+    public String getExample() {
+        return example == null ? "" : example;
+    }
+
+    public String getSee() {
+        return see == null ? "" : see;
+    }
+
+    public void parseComments(ArrayList<String> comments) {
+        String currBlock = null, block = null;
+        for (String comment : comments) {
+            boolean newBlock = false;
+            String lowerComment = comment.toLowerCase();
+            int i;
+
+            // if we find a tag, start a new block
+            if (((i = lowerComment.indexOf(block = Tokens.AUTHOR)) >= 0)
+            || ((i = lowerComment.indexOf(block = Tokens.DATE)) >= 0)
+                || ((i = lowerComment.indexOf(block = Tokens.SEE)) >= 0)
+                || ((i = lowerComment.indexOf(block = Tokens.RETURN)) >= 0)
+                || ((i = lowerComment.indexOf(block = Tokens.PARAM)) >= 0)
+                || ((i = lowerComment.indexOf(block = Tokens.EXCEPTION)) >= 0)
+                || ((i = lowerComment.indexOf(block = Tokens.DEPRECATED)) >= 0)
+                || ((i = lowerComment.indexOf(block = Tokens.DESCRIPTION)) >= 0)
+                || ((i = lowerComment.indexOf(block = Tokens.GROUP)) >= 0)
+                || ((i = lowerComment.indexOf(block = Tokens.GROUP_CONTENT)) >= 0)
+                || ((i = lowerComment.indexOf(block = Tokens.EXAMPLE)) >= 0)) {
+
+                    comment = comment.substring(i + block.length());
+                    currBlock = block;
+                    newBlock = true;
+                }
+
+                // get everything after first '*'
+                String line = "";
+                comment = comment.trim();
+                for (int j = 0; j < comment.length(); ++j) {
+                    char ch = comment.charAt(j);
+                    if (ch != '*') {
+                        line = comment.substring(j);
+                        break;
+                    }
+                }
+
+            // add line to appropriate block...
+            // if currBlock was not reset on this iteration we're on the next line of the last token, add line
+            // to that value. Allow empty lines in example blocks to preserve whitespace in complex examples
+            if (currBlock != null && (!line.trim().isEmpty() || line.trim().isEmpty() && currBlock.equals(Tokens.EXAMPLE))) {
+                if (currBlock.equals(Tokens.AUTHOR)) {
+                    author += (!author.isEmpty() ? " " : "") + line.trim();
+                } else if (currBlock.equals(Tokens.DATE)) {
+                    date += (!date.isEmpty() ? " " : "") + line.trim();
+                } else if (currBlock.equals(Tokens.SEE)) {
+                    see += (!see.isEmpty() ? " " : "") + line.trim();
+                } else if (currBlock.equals(Tokens.RETURN)) {
+                    returns += (!returns.isEmpty() ? " " : "") + line.trim();
+                } else if (currBlock.equals(Tokens.PARAM)) {
+                    String p = (newBlock ? "" : params.remove(params.size() - 1));
+                    params.add(p + (!p.isEmpty() ? " " : "") + line.trim());
+                } else if (currBlock.equals(Tokens.EXCEPTION)) {
+                    exception += (!exception.isEmpty() ? " " : "") + line.trim();
+                } else if (currBlock.equals(Tokens.DEPRECATED)) {
+                    deprecated += (!deprecated.isEmpty() ? " " : "") + line.trim();
+                } else if (currBlock.equals(Tokens.DESCRIPTION)) {
+                    description += (!description.isEmpty() ? " " : "") + line.trim();
+                } else if (currBlock.equals(Tokens.GROUP)) {
+                    classGroup += (!classGroup.isEmpty() ? " " : "") + line.trim();
+                } else if (currBlock.equals(Tokens.GROUP_CONTENT)) {
+                    classGroupContent += (!classGroupContent.isEmpty() ? " " : "") + line.trim();
+                } else if (currBlock.equals(Tokens.EXAMPLE)) {
+                    example += (!example.isEmpty() ? "\n" : "") + line;
+                }
             }
         }
     }

--- a/src/main/ClassModel.java
+++ b/src/main/ClassModel.java
@@ -10,8 +10,6 @@ public class ClassModel extends ApexModel {
 
     private ArrayList<MethodModel> methods;
     private ArrayList<PropertyModel> properties;
-    private String classGroup;
-    private String classGroupContent;
     private ClassModel cmodelParent;
     private ArrayList<ClassModel> childClasses;
     private boolean isInterface;
@@ -142,16 +140,8 @@ public class ClassModel extends ApexModel {
         }
     }
 
-    public void setClassGroup(String group) {
-        this.classGroup = group;
-    }
-
     public String getClassGroupContent() {
         return classGroupContent;
-    }
-
-    public void setClassGroupContent(String groupContent) {
-        this.classGroupContent = groupContent;
     }
 
     public boolean getIsInterface() {

--- a/src/main/MethodModel.java
+++ b/src/main/MethodModel.java
@@ -4,13 +4,6 @@ import java.util.ArrayList;
 
 public class MethodModel extends ApexModel {
 
-    private ArrayList<String> params;
-    private String exceptions;
-
-    public MethodModel() {
-        params = new ArrayList<String>();
-    }
-
     public void setNameLine(String nameLine, int lineNum) {
         // remove anything after the parameter list
         if (nameLine != null) {
@@ -26,16 +19,12 @@ public class MethodModel extends ApexModel {
         return params;
     }
 
-    public void setException(String exceptions) {
-        this.exceptions = exceptions;
-    }
-
     public String getException() {
-        return exceptions == null ? "" : exceptions;
+        return exception == null ? "" : exception;
     }
 
-    public void setParams(ArrayList<String> params) {
-        this.params = params;
+    public String getReturns() {
+        return returns == null ? "" : returns;
     }
 
     public String getMethodName() {

--- a/src/main/PropertyModel.java
+++ b/src/main/PropertyModel.java
@@ -2,7 +2,7 @@ package main;
 
 public class PropertyModel extends ApexModel {
 
-    public void setNameLine(String nameLine, int iLine) {
+    public void setNameLine(String nameLine, int lineNum) {
         if (nameLine != null) {
             // remove any trailing stuff after property name. { =
             int i = nameLine.indexOf('{');
@@ -11,7 +11,7 @@ public class PropertyModel extends ApexModel {
             if (i >= 0) nameLine = nameLine.substring(0, i);
         }
 
-        super.setNameLine(nameLine, iLine);
+        super.setNameLine(nameLine, lineNum);
     }
 
     public String getPropertyName() {


### PR DESCRIPTION
  * replace three fill* methods in ApexDoc.java with create* methods which utilize a common `commentParser` method found on the base ApexModel.java class
  * this removes the need for 300+ lines of code and significantly improves multi-line support across all tokens
  * based almost exactly on solution from SFApexDoc, another fork of the original ApexDoc

closes #14 